### PR TITLE
use execSync to curl at unix socket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM mhart/alpine-node
 
+RUN apk add --update curl && \
+    rm -rf /var/cache/apk/*
+
 COPY package.json /src/
 
 RUN cd /src; npm install --production

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -525,6 +525,8 @@ async function startDockerContainer(name) {
   }
 }
 
+const execSync = require('child_process').execSync;
+
 async function createDockerContainer(Image, name) {
   const image = `${Image}:${name}`;
   try {
@@ -532,7 +534,12 @@ async function createDockerContainer(Image, name) {
     await docker.post(`/images/${Image}/json`);
   } catch (err) {
     console.log(`${image} not found. Downloading...`);
-    await docker.post(`/images/create?fromImage=${image}`);
+    // this is currently not working for unknown reason
+    // await docker.post(`/images/create?fromImage=${image}`);
+    // Reason for "http://wat" is due to https://github.com/docker/docker/issues/26099#issuecomment-256880358
+    // eslint-disable-next-line max-len
+    const command = `curl -v -XPOST --unix-socket /var/run/docker.sock "http:/wat/images/create?fromImage=${image}"`;
+    execSync(command);
   }
   try {
     console.log(`Creating container ${name} from ${image}...`);


### PR DESCRIPTION
Creating new containers seems to work when running the API locally, but when running via docker-compose from deploybot-deploy it errors with


```json
{
  "data": {
    "createContainer": {
      "clientMutationId": "0",
      "containerEdge": null,
      "viewer": {
        "id": "VXNlcjox"
      }
    }
  },
  "errors": [
    {
      "message": "Cannot read property 'id' of undefined",
      "locations": [
        {
          "line": 1,
          "column": 319
        }
      ],
      "path": [
        "createContainer",
        "containerEdge"
      ]
    }
  ]
}
```